### PR TITLE
Use different port for dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --port 8070",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
The GUI uses port 3000.
The homepage uses 5173.
The servers  uses 8080.

So I made this use port 8070.

The reasoning for this change is that I really do not want to have to turn off any other development server just to run the docs locally.